### PR TITLE
Add useColorEscapeCodes option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function (grunt) {
 
     var JasmineConsoleReporter = require('./index');
     var reporter = new JasmineConsoleReporter({
-        colors: true,
+        colors: true,        // (0|false)|(1|true)|2
         cleanStack: 1,       // (0|false)|(1|true)|2|3
         verbosity: 4,        // (0|false)|1|2|(3|true)|4
         listStyle: 'indent', // "flat"|"indent"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Console Reporter for Jasmine. Outputs detailed test results to the console, with beautiful layout and colors. This is the default reporter of [grunt-jasmine-nodejs][grunt-jn].
 
-> Author: Onur Yıldırım (onury) © 2016  
+> Author: Onur Yıldırım (onury) © 2016
 > Licensed under the MIT License.
 
 Example output from [grunt-jasmine-nodejs][grunt-jn].
@@ -28,7 +28,8 @@ var reporter = new JasmineConsoleReporter({
     cleanStack: 1,       // (0|false)|(1|true)|2|3
     verbosity: 4,        // (0|false)|1|2|(3|true)|4
     listStyle: 'indent', // "flat"|"indent"
-    activity: false
+    activity: false,
+    useColorEscapeCodes: false
 });
 // pass the initialized reporter to whichever task or host...
 ```
@@ -50,6 +51,8 @@ Indicates the style of suites/specs list output. Possible values: `"flat"` or `"
 + **activity** — Type: `Boolean` Default: `false`  
 Specifies whether to enable the activity indicator animation that outputs the current spec that is being executed. If your tests log extra data to console, this option should be disabled or they might be overwritten.
 
++ **useColorEscapeCodes** — Type: `Boolean` Default: `false`
+Specifies whether or not to use the [Chalk styles exposed as ANSI escape codes](https://www.npmjs.com/package/chalk#chalkstyles). This option can be useful if, for example, you're running your tests from a sub-process, and the colors aren't showing up. If `options.colors` is `false`, this option has no effect.
 
 ## Change-Log
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 Console Reporter for Jasmine. Outputs detailed test results to the console, with beautiful layout and colors. This is the default reporter of [grunt-jasmine-nodejs][grunt-jn].
 
-> Author: Onur Yıldırım (onury) © 2016
-
+> Author: Onur Yıldırım (onury) © 2016  
 > Licensed under the MIT License.
 
 Example output from [grunt-jasmine-nodejs][grunt-jn].
@@ -52,8 +51,7 @@ Indicates the style of suites/specs list output. Possible values: `"flat"` or `"
 + **activity** — Type: `Boolean` Default: `false`  
 Specifies whether to enable the activity indicator animation that outputs the current spec that is being executed. If your tests log extra data to console, this option should be disabled or they might be overwritten.
 
-+ **useColorEscapeCodes** — Type: `Boolean` Default: `false`
-
++ **useColorEscapeCodes** — Type: `Boolean` Default: `false`  
 Specifies whether or not to use the [Chalk styles exposed as ANSI escape codes](https://www.npmjs.com/package/chalk#chalkstyles). This option can be useful if, for example, you're running your tests from a sub-process, and the colors aren't showing up. If `options.colors` is `false`, this option has no effect.
 
 ## Change-Log

--- a/README.md
+++ b/README.md
@@ -24,20 +24,19 @@ npm install jasmine-console-reporter
 ```js
 var JasmineConsoleReporter = require('jasmine-console-reporter');
 var reporter = new JasmineConsoleReporter({
-    colors: true,
+    colors: true,        // (0|false)|(1|true)|2
     cleanStack: 1,       // (0|false)|(1|true)|2|3
     verbosity: 4,        // (0|false)|1|2|(3|true)|4
     listStyle: 'indent', // "flat"|"indent"
-    activity: false,
-    useColorEscapeCodes: false
+    activity: false
 });
 // pass the initialized reporter to whichever task or host...
 ```
 
 ### Options
 
-+ **colors** — Type: `Boolean` Default: `true`  
-Specifies whether the output should have colored text.
++ **colors** — Type: `Number`|`Boolean` Default: `1`  
+Specifies whether the output should have colored text. Possible integer values: 0 to 2. Set to `1` (or `true`) to enable colors, and `0` (or `false`) to disable colors. Set to `2` to use the [Chalk styles exposed as ANSI escape codes](https://www.npmjs.com/package/chalk#chalkstyles). Option `2` can be useful if, for example, you're running your tests from a sub-process, and the colors aren't showing up.
 
 + **cleanStack** — Type: `Number|Boolean` Default: `1`  
 Specifies the filter level for the error stacks. Possible integer values: 0 to 3. Set to `1` (or `true`) to only filter out lines with jasmine-core path from stacks. Set to `2` to filter out all `node_modules` paths. Set to `3` to also filter out lines with no file path in it.
@@ -50,9 +49,6 @@ Indicates the style of suites/specs list output. Possible values: `"flat"` or `"
 
 + **activity** — Type: `Boolean` Default: `false`  
 Specifies whether to enable the activity indicator animation that outputs the current spec that is being executed. If your tests log extra data to console, this option should be disabled or they might be overwritten.
-
-+ **useColorEscapeCodes** — Type: `Boolean` Default: `false`  
-Specifies whether or not to use the [Chalk styles exposed as ANSI escape codes](https://www.npmjs.com/package/chalk#chalkstyles). This option can be useful if, for example, you're running your tests from a sub-process, and the colors aren't showing up. If `options.colors` is `false`, this option has no effect.
 
 ## Change-Log
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 Console Reporter for Jasmine. Outputs detailed test results to the console, with beautiful layout and colors. This is the default reporter of [grunt-jasmine-nodejs][grunt-jn].
 
 > Author: Onur Yıldırım (onury) © 2016
+
 > Licensed under the MIT License.
 
 Example output from [grunt-jasmine-nodejs][grunt-jn].
@@ -52,6 +53,7 @@ Indicates the style of suites/specs list output. Possible values: `"flat"` or `"
 Specifies whether to enable the activity indicator animation that outputs the current spec that is being executed. If your tests log extra data to console, this option should be disabled or they might be overwritten.
 
 + **useColorEscapeCodes** — Type: `Boolean` Default: `false`
+
 Specifies whether or not to use the [Chalk styles exposed as ANSI escape codes](https://www.npmjs.com/package/chalk#chalkstyles). This option can be useful if, for example, you're running your tests from a sub-process, and the colors aren't showing up. If `options.colors` is `false`, this option has no effect.
 
 ## Change-Log

--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ module.exports = (function () {
             cleanStack: 1, // 0 to 3
             verbosity: 4,  // 0 to 4
             activity: false,
-            listStyle: 'indent'
+            listStyle: 'indent',
+            useColorEscapeCodes: false
         }, options);
 
         var report = {
@@ -102,7 +103,13 @@ module.exports = (function () {
 
         function fnStyle(color) {
             return function (str) {
-                return options.colors ? chalk[color](str) : str;
+                if (!options.colors) {
+                    return str;
+                }
+                if (options.useColorEscapeCodes) {
+                    return chalk.styles[color].open + str + chalk.styles[color].close;
+                }
+                return chalk[color](str);
             };
         }
 

--- a/index.js
+++ b/index.js
@@ -33,15 +33,15 @@ module.exports = (function () {
         options = options || {};
         options.verbosity = utils.optionBoolToNum(options.verbosity, 4, 0);
         options.cleanStack = utils.optionBoolToNum(options.cleanStack, 1, 0);
+        options.colors = utils.optionBoolToNum(options.colors, 1, 0);
 
         // extend options with defaults
         options = utils.extend({
-            colors: true,
+            colors: 1,     // 0 to 2
             cleanStack: 1, // 0 to 3
             verbosity: 4,  // 0 to 4
             activity: false,
-            listStyle: 'indent',
-            useColorEscapeCodes: false
+            listStyle: 'indent'
         }, options);
 
         var report = {
@@ -103,13 +103,14 @@ module.exports = (function () {
 
         function fnStyle(color) {
             return function (str) {
-                if (!options.colors) {
-                    return str;
+                switch (options.colors) {
+                    case 2:
+                        return chalk.styles[color].open + str + chalk.styles[color].close;
+                    case 1:
+                        return chalk[color](str);
+                    default:
+                        return str;
                 }
-                if (options.useColorEscapeCodes) {
-                    return chalk.styles[color].open + str + chalk.styles[color].close;
-                }
-                return chalk[color](str);
             };
         }
 


### PR DESCRIPTION
This gives the option to use the chalk styles exposed as ANSI escape codes as described [on the chalk page](https://www.npmjs.com/package/chalk#chalkstyles). I was running my tests from a sub-process and the colors weren't showing up - this change fixed it for me.