### PR TITLE
Report random seed with verbosity 1 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [next](https://github.com/onury/jasmine-console-reporter/compare/v3.0.0...master) (TBD)
+
+### Changed
+- Randomness and random seed displayed if running in random order and `verbosity` is `1` or above.
+
 ## [3.0.0](https://github.com/onury/jasmine-console-reporter/compare/v2.0.1...v3.0.0) (2018-04-03)
 > _This major version is re-written in ES2015. See breaking changes below._
 

--- a/index.js
+++ b/index.js
@@ -196,9 +196,9 @@ class JasmineConsoleReporter {
         this.print.str('Executing ' + summary.totalSpecsDefined + ' defined specs...');
 
         const isRandom = summary.order && summary.order.random;
-        if (this.report.listAll && isRandom) {
+        if (this.report.stats && isRandom) {
             this.print.newLine();
-            this.print.str(this.style.gray('Running in random order...')); // (seed: ' + summary.order.seed + ')'));
+            this.print.str(this.style.gray('Running in random order... (seed: ' + summary.order.seed + ')'));
         }
         this.print.newLine();
 


### PR DESCRIPTION
If the test run is executing in random order, this adds the random seed number to the message printed at the beginning of the session so that testers can reproduce the same order.

It also changes this information (which is just a single line) to be reported at the `stats` level, rather than at the most-verbose `listAll` level.

This is done because when running in random mode, it's often vital to know what seed was used to run the tests in order to reproduce a failure. If the verbosity needs to be increased upon seeing a failure in order to debug it, it's often too late as subsequent runs will use a different seed that may no longer reproduce the issue.